### PR TITLE
Temporary Wayland fix

### DIFF
--- a/net.rpcs3.RPCS3.yaml
+++ b/net.rpcs3.RPCS3.yaml
@@ -17,6 +17,7 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland
+  - --env=QT_QPA_PLATFORM=xcb
   - --share=network
   - --talk-name=org.a11y.Bus
   - --talk-name=org.gtk.vfs.*


### PR DESCRIPTION
This variable must be set until the Wayland support is finished. Otherwise, the tool will crash on some distros after running a game.

(Why? Some distros have set this global variable: QT_QPA_PLATFORM=wayland to force the Wayland compatibility since some tools can't do this on their own and this works for most applications except more complex applications like emulators where you need to modify the backend a bit before it will run)

Same issue as here:
[#79](https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/79)