### PR TITLE
Update commits once a day at most

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,24 @@
+name: Update commit hashes
+on:
+  schedule:
+    - cron: "0 0 * * *" # Every day at 00:00
+
+jobs:
+  flatpak-external-data-checker:
+    name: Change the commit hashes to the latest upstream ones
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Change commit hashes
+        uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        with:
+          args: --commit-only net.rpcs3.RPCS3.yaml
+      - name: Push the change
+        run: git push origin HEAD:master

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,4 @@
 {
   "automerge-flathubbot-prs": true,
-  "only-arches": ["x86_64"],
-  "publish-delay-hours": 0
+  "only-arches": ["x86_64"]
 }

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
-  "automerge-flathubbot-prs": true,
+  "disable-external-data-checker": true,
   "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Follow up of #https://github.com/flathub/net.rpcs3.RPCS3/pull/675.

Benefits:
- less load on the Flathub CI servers 
- prevents to have several PRs opened in a short time between each other, and then to have to close them manually