### PR TITLE
Update commits once a day

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,22 @@
+name: Check for updates
+on:
+  schedule: # for scheduling to work this file must be in the default branch
+  - cron: "0 0 * * *" # Every day at 00:00
+  workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab
+
+jobs:
+  flatpak-external-data-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
+        env:
+          GIT_AUTHOR_NAME: Flatpak External Data Checker
+          GIT_COMMITTER_NAME: Flatpak External Data Checker
+          # email sets "github-actions[bot]" as commit author, see https://github.community/t/github-actions-bot-email-address/17204/6
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --update --never-fork net.rpcs3.RPCS3.yaml

--- a/flathub.json
+++ b/flathub.json
@@ -1,5 +1,5 @@
 {
   "automerge-flathubbot-prs": true,
-  "only-arches": ["x86_64"],
-  "publish-delay-hours": 0
+  "disable-external-data-checker": true,
+  "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Follow up of https://github.com/flathub/net.rpcs3.RPCS3/pull/1016.
This is taken from https://github.com/flathub/net.rpcs3.RPCS3/pull/1016, and after a test on another repository - it indeed works: a PR will be opened, as it would be done by @flathubbot.

As a side note the current failures are from the linter, which no longer accept a `branch` field. This is very inconvenient because it is used by f-e-d-c to know from which branch the latest commit has to be retrieved. 