### PR TITLE
Fix flatpak-builder linter errors

### DIFF
--- a/net.rpcs3.RPCS3.yaml
+++ b/net.rpcs3.RPCS3.yaml
@@ -29,6 +29,7 @@ add-extensions:
     autodelete: false
 cleanup-commands:
   - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
+
 modules:
   - shared-modules/glu/glu-9.json
   - shared-modules/glew/glew.json
@@ -53,62 +54,15 @@ modules:
           stable-only: true
           url-template: https://www.freedesktop.org/software/libevdev/libevdev-$version.tar.xz
 
-  - name: rpcs3-llvm
-    buildsystem: cmake-ninja
-    builddir: true
-    build-options:
-      cflags: &optflags -O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong
-        -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection
-        -fcf-protection -fno-omit-frame-pointer
-      cflags-override: true
-      cxxflags: -O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong
-        -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection
-        -fcf-protection -fno-omit-frame-pointer -msse -msse2 -mcx16
-      cxxflags-override: true
-      env:
-        AR: llvm-ar
-        CC: clang
-        CXX: clang++
-        RANLIB: llvm-ranlib
-      ldflags: -fuse-ld=lld
-      prepend-ld-library-path: /usr/lib/sdk/llvm14/lib
-      prepend-path: /usr/lib/sdk/llvm14/bin
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_SHARED_LIBS=OFF
-      - -DLLVM_CCACHE_BUILD=ON
-      - -DLLVM_TARGETS_TO_BUILD='X86'
-      - -DLLVM_BUILD_RUNTIME=OFF
-      - -DLLVM_BUILD_TOOLS=OFF
-      - -DLLVM_INCLUDE_DOCS=OFF
-      - -DLLVM_INCLUDE_EXAMPLES=OFF
-      - -DLLVM_INCLUDE_TESTS=OFF
-      - -DLLVM_INCLUDE_TOOLS=OFF
-      - -DLLVM_INCLUDE_UTILS=OFF
-      - -DLLVM_USE_INTEL_JITEVENTS=ON
-      - -DLLVM_USE_PERF=ON
-      - -DLLVM_ENABLE_Z3_SOLVER=OFF
-      - -DCMAKE_CXX_STANDARD=17
-      - -DITTAPI_SOURCE_DIR=/run/build/rpcs3-llvm/ittapi
-      - -Wno-dev
-    cleanup:
-      - '*'
-    sources:
-      - type: git
-        url: https://github.com/RPCS3/llvm-mirror.git
-        commit: c725f494c91611018f5d830eca22c0a1662c0f31
-      - type: git
-        url: https://github.com/intel/ittapi.git
-        dest: ittapi/ittapi
-        disable-shallow-clone: true
-
   - name: rpcs3
     buildsystem: cmake-ninja
     builddir: true
     build-options:
       append-ld-library-path: /usr/lib/sdk/llvm14/lib
       append-path: /usr/lib/sdk/llvm14/bin
-      cflags: *optflags
+      cflags: &optflags -O2 -g -pipe -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong
+        -grecord-gcc-switches -fasynchronous-unwind-tables -fstack-clash-protection
+        -fcf-protection -fno-omit-frame-pointer
       cflags-override: true
       cxxflags: *optflags
       cxxflags-override: true
@@ -120,26 +74,33 @@ modules:
       ldflags: -fuse-ld=lld
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DBUILD_LLVM_SUBMODULE=OFF
+      - -DBUILD_LLVM_SUBMODULE=ON
       - -DUSE_NATIVE_INSTRUCTIONS=OFF
       - -DUSE_PRECOMPILED_HEADERS=OFF
       - -DUSE_SYSTEM_CURL=ON
       - -DUSE_SYSTEM_FFMPEG=ON
       - -DUSE_SYSTEM_LIBPNG=ON
       - -DUSE_SYSTEM_ZLIB=ON
+      - -DITTAPI_SOURCE_DIR=/run/build/rpcs3/ittapi
       - -Wno-dev
     post-install:
-      - |
-        set -eux;
+      - |-
+        set -eux
 
-        sed -i 's|<id>RPCS3</id>|<id>net.rpcs3.RPCS3</id>|' ${FLATPAK_DEST}/share/metainfo/rpcs3.metainfo.xml;
+        sed -i 's|<id>RPCS3</id>|<id>net.rpcs3.RPCS3</id>|' ${FLATPAK_DEST}/share/metainfo/rpcs3.metainfo.xml
 
-        COMM_TAG="$(awk -F'[\{,]' '/version{.*}/{printf "%d.%d.%d", $2, $3, $4}' ../rpcs3/rpcs3_version.cpp)";
+        COMM_TAG="$(awk -F'[\{,]' '/version{.*}/{printf "%d.%d.%d", $2, $3, $4}' ../rpcs3/rpcs3_version.cpp)"
         COMM_COUNT="$(git rev-list --count HEAD)";
         COMM_HASH="$(git rev-parse --short=8 HEAD)";
-        sed -i 's|</component>|<content_rating type="oars-1.1"/><releases><release date="'$(git show -s --format=%cs)'" version="'"${COMM_TAG}"'-'"${COMM_COUNT}"'-'"${COMM_HASH}"'"/></releases></component>|' ${FLATPAK_DEST}/share/metainfo/rpcs3.metainfo.xml;
+        sed -i 's|</component>|<content_rating type="oars-1.1"/><releases><release date="'$(git show -s --format=%cs)'" version="'"${COMM_TAG}"'-'"${COMM_COUNT}"'-'"${COMM_HASH}"'"/></releases></component>|' ${FLATPAK_DEST}/share/metainfo/rpcs3.metainfo.xml
     sources:
       - type: git
         url: https://github.com/RPCS3/rpcs3.git
         branch: master
-        commit: 73784b9e1218cf5ffe8044191b3f8eecac0c16e6
+        commit: 3fe9aea5b55b54aa5adb051b568d7eec6e2d38f1
+      - type: git
+        url: https://github.com/intel/ittapi.git
+        branch: master
+        commit: 2428ed97aa977c66b30940081e7d3e9b1a3c7402
+        dest: ittapi/ittapi
+        disable-shallow-clone: true


### PR DESCRIPTION
Makes the Flatpak build again:
- the lint error was due to the missing `commit` field in `https://github.com/intel/ittapi`. The `branch` field is put for f-e-d-c.
- `RelWithDebInfo` is a non-blocking warning, but no disadvantage of adding it.
- I updated the commits