### PR TITLE
Add merge workflow

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,7 +1,7 @@
-name: Check for updates
+name: Merge any pull request
 on:
   schedule: # for scheduling to work this file must be in the default branch
-  - cron: "30 0 * * *" # Every day at 00:30
+  - cron: "0 1 * * *" # Every day at 01:00
   workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab
 
 jobs:
@@ -19,4 +19,4 @@ jobs:
           EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --update --never-fork net.rpcs3.RPCS3.yaml
+          args: --edit-only net.rpcs3.RPCS3.yaml

--- a/net.rpcs3.RPCS3.yaml
+++ b/net.rpcs3.RPCS3.yaml
@@ -97,7 +97,7 @@ modules:
       - type: git
         url: https://github.com/RPCS3/rpcs3.git
         branch: master
-        commit: 035d410a8967e9b7d9ec38f7ef6a3b7f415a2fec
+        commit: 7ea0a6d642092010449e7593bbb2f3aff24ef9b6
       - type: git
         url: https://github.com/intel/ittapi.git
         branch: master


### PR DESCRIPTION
Solves #1235 hopefully.
30min of dealy should be enough, unless the GitHub delays the schedule of the first cron to late, and executes the second "merge" workflow right away. We will see.
This should be mitigated somewhat by 00:30 not being an even hour, so with less loads on the GitHub Actions workers overall: [High load times include the start of every hour](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#schedule). This will not be the case for the "merge" workflow, running at 1:00.