### PR TITLE
Use single quotes if

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Prevent the retrieval of newer commits
-        if: github.event.schedule == "30 1 * * *"
+        if: github.event.schedule == '30 1 * * *'
         run: "sed -i '/^        branch: master/d' net.rpcs3.RPCS3.yaml"
       - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:


### PR DESCRIPTION
The GitHub Actions workflow yaml file was valid, yet the if condition only seems to accepts singles quotes, not double quotes...
Hopefully it runs finally.
Note: I just noticed I can check on my fork the workflow syntax, a run is done there, but for some reason it only runs once.