### PR TITLE
Remove if condition in workflow

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,7 +2,7 @@ name: Check for updates
 on:
   schedule: # for scheduling to work this file must be in the default branch
   - cron: "30 0 * * *" # Every day at 00:30
-  - cron: "30 1 * * *" # merge the next hour
+  - cron: "30 1 * * *"
   workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab
 
 jobs:
@@ -10,9 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Prevent the retrieval of newer commits
-        if: github.event.schedule == '30 1 * * *'
-        run: "sed -i '/^        branch: master/d' net.rpcs3.RPCS3.yaml"
       - uses: docker://ghcr.io/flathub/flatpak-external-data-checker:latest
         env:
           GIT_AUTHOR_NAME: Flatpak External Data Checker


### PR DESCRIPTION
At least we tried. I suspect f-e-d-c uses the hash retrieved to check for existing PRs.
There will be a chance to have 2 PRs, but will still be better than nothing.