### PR TITLE
Clean up and update build, remove unnecessary modules

### DIFF
--- a/net.rpcs3.RPCS3.yaml
+++ b/net.rpcs3.RPCS3.yaml
@@ -79,3 +79,5 @@ modules:
         url: https://github.com/RPCS3/rpcs3.git
         branch: master
         commit: 260c98618614c070067c6b0b1a82f2e8199d7d4a
+      - type: patch
+        path: rehost-metainfo-screenshot.patch

--- a/rehost-metainfo-screenshot.patch
+++ b/rehost-metainfo-screenshot.patch
@@ -1,0 +1,11 @@
+--- a/rpcs3/rpcs3.metainfo.xml    2026-02-24 18:05:30.212700447 +0100
++++ b/rpcs3/rpcs3.metainfo.xml    2026-02-24 18:09:02.057700515 +0100
+@@ -22,7 +22,7 @@
+     <screenshots>
+         <screenshot type="default">
+             <caption>RPCS3 running a game using the Vulkan backend</caption>
+-            <image type="source">https://rpcs3.net/blog/wp-content/uploads/2017/05/progress/vklinux.jpg</image>
++            <image type="source">https://i.imgur.com/ounMfm3.png</image>
+         </screenshot>
+     </screenshots>
+     <url type="homepage">https://rpcs3.net</url>


### PR DESCRIPTION
Switches a bunch of things to the versions that are part of the base platform, only protobuf had to be kept as the rpcs3 vendored copy due to a requirement for a more modern version.